### PR TITLE
Update supporter.py

### DIFF
--- a/supporter.py
+++ b/supporter.py
@@ -284,11 +284,10 @@ class Supporter:
     def autoID(self, client, username):
         if not self.cl == None:
             # really janky code that automatically sets user ID
-            if self.get_client_statedata(client)["type"] != "scratch": # Prevent this from breaking compatibility with scratch clients
-                self.modify_client_statedata(client, "username", username)
-                self.cl.statedata["ulist"]["usernames"][username] = client["id"]
-                self.sendPacket({"cmd": "ulist", "val": self.cl._get_ulist()})
-                self.log("{0} autoID given".format(username))
+            self.modify_client_statedata(client, "username", username)
+            self.cl.statedata["ulist"]["usernames"][username] = client["id"]
+            self.sendPacket({"cmd": "ulist", "val": self.cl._get_ulist()})
+            self.log("{0} autoID given".format(username))
     
     def kickBadUsers(self, username):
         if not self.cl == None:


### PR DESCRIPTION
Remove this to stop clients from authenticating but not getting assigned an ID (being authenticated and not having an ID allows for some weird behavior). I don't see how this would really effect Scratch clients apart from maybe "Username Synced". But since this is for Meower and Meower uses CL Turbo now it should be fine removing this line.