### PR TITLE
Mongo version of Meower Server -- Big patch

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,12 +50,12 @@ class Main:
         )
         
         # Load trust keys
-        result, payload = self.filesystem.load_file("/Config/trust_keys.json")
+        result, payload = self.filesystem.load_item("config", "trust_keys")
         if result:
             self.cl.trustedAccess(True, payload["index"])
         
         # Load IP Banlist
-        result, payload = self.filesystem.load_file("/Jail/IPBanlist.json")
+        result, payload = self.filesystem.load_item("config", "IPBanlist")
         if result:
             self.cl.loadIPBlocklist(payload["wildcard"])
         
@@ -89,9 +89,18 @@ class Main:
             elif cmd == "update_config":
                 # Update client settings
                 self.meower.update_config(client, val, listener_detected, listener_id)
+            elif cmd == "del_account":
+                # Delete user account
+                self.meower.del_account(client, listener_detected, listener_id)
             elif cmd == "get_home":
                 # Get homepage index
                 self.meower.get_home(client, listener_detected, listener_id)
+            elif cmd == "get_inbox":
+                # Get inbox posts
+                self.meower.get_inbox(client, val, listener_detected, listener_id)
+            elif cmd == "get_announcements":
+                # Get announcement posts
+                self.meower.get_announcements(client, val, listener_detected, listener_id)
             elif cmd == "post_home":
                 # Create post for homepage
                 self.meower.post_home(client, val, listener_detected, listener_id)
@@ -105,8 +114,17 @@ class Main:
                 # Get user's posts
                 self.meower.search_user_posts(client, val, listener_detected, listener_id)
             elif cmd == "clear_home":
-                # Get current peak # of users data
-                self.meower.clear_home(client, listener_detected, listener_id)
+                # Clear a page of home
+                self.meower.clear_home(client, val, listener_detected, listener_id)
+            elif cmd == "clear_user_posts":
+                # Clear all of a user's posts
+                self.meower.clear_user_posts(client, val, listener_detected, listener_id)
+            elif cmd == "alert":
+                # Send alert to a user
+                self.meower.alert(client, val, listener_detected, listener_id)
+            elif cmd == "announce":
+                # Send global announcement
+                self.meower.announce(client, val, listener_detected, listener_id)
             elif cmd == "block":
                 # Block IP address (wildcard mode)
                 self.meower.block(client, val, listener_detected, listener_id)
@@ -119,6 +137,9 @@ class Main:
             elif cmd == "get_user_ip":
                 # Get user IP addresses
                 self.meower.get_user_ip(client, val, listener_detected, listener_id)
+            elif cmd == "get_ip_data":
+                # Return netlog data of an IP
+                self.meower.get_ip_data(client, val, listener_detected, listener_id)
             elif cmd == "get_user_data":
                 # Return full account data (excluding password hash)
                 self.meower.get_user_data(client, val, listener_detected, listener_id)
@@ -129,10 +150,17 @@ class Main:
                 # Pardon users
                 self.meower.pardon(client, val, listener_detected, listener_id)
             elif cmd == "ip_ban":
-                # Ban users
+                # Ban IPs
                 self.meower.ip_ban(client, val, listener_detected, listener_id)
             elif cmd == "ip_pardon":
+                # Pardon IPs
                 self.meower.ip_pardon(client, val, listener_detected, listener_id)
+            elif cmd == "terminate":
+                # Terminate users
+                self.meower.terminate(client, val, listener_detected, listener_id)
+            elif cmd == "repair_mode":
+                # Enable repair mode
+                self.meower.repair_mode(client, listener_detected, listener_id)
             elif cmd == "delete_post":
                 # Delete posts
                 self.meower.delete_post(client, val, listener_detected, listener_id)
@@ -143,17 +171,26 @@ class Main:
                 # Set chat state
                 self.meower.set_chat_state(client, val, listener_detected, listener_id)
             elif cmd == "create_chat":
+                # Create group chat
                 self.meower.create_chat(client, val, listener_detected, listener_id)
             elif cmd == "leave_chat":
+                # Leave group chat
                 self.meower.leave_chat(client, val, listener_detected, listener_id)
             elif cmd == "get_chat_list":
-                self.meower.get_chat_list(client, val, listener_detected, listener_id)
+                # Get group chat list
+                self.meower.get_chat_list(client, listener_detected, listener_id)
             elif cmd == "get_chat_data":
+                # Get group chat data
                 self.meower.get_chat_data(client, val, listener_detected, listener_id)
-            elif cmd == "get_chat_post":    
-                self.meower.get_chat_post(client, val, listener_detected, listener_id)
+            elif cmd == "get_chat_posts":
+                # Get group chat posts
+                self.meower.get_chat_posts(client, val, listener_detected, listener_id)
             elif cmd == "add_to_chat":
+                # Add someone to group chat
                 self.meower.add_to_chat(client, val, listener_detected, listener_id)
+            elif cmd == "remove_from_chat":
+                # Remove someone from group chat
+                self.meower.remove_from_chat(client, val, listener_detected, listener_id)
             
             # Lol whitespace for future code
 
@@ -164,4 +201,4 @@ class Main:
             self.supporter.log("{0}".format(self.supporter.full_stack()))
 
 if __name__ == "__main__":
-    Main(debug=False)
+    Main(debug=True)

--- a/meower.py
+++ b/meower.py
@@ -1069,8 +1069,7 @@ class Meower:
                             for post_id in all_posts:
                                 result, payload = self.filesystem.load_item("posts", post_id)
                                 if result:
-                                    payload["u"] = "Deleted"
-                                    payload["p"] = "[This user was deleted]"
+                                    payload["isDeleted"] = True
                                     self.filesystem.write_item("posts", post_id, payload)
                             FileCheck, FileRead, FileWrite = self.accounts.update_setting(val, {"theme": None, "mode": None, "sfx": None, "debug": None, "bgm": None, "bgm_song": None, "layout": None, "pfp_data": None, "quote": None, "email": None, "pswd": None, "lvl": None, "banned": True, "last_ip": None}, forceUpdate=True)
                             if FileCheck and FileRead and FileWrite:
@@ -1696,7 +1695,8 @@ class Meower:
                         result, payload = self.filesystem.load_item("posts", post_id)
                         if result:
                             payload["u"] = "Deleted"
-                            payload["p"] = "[This user was deleted]"
+                            payload["p"] = "[This user was deleted - GDPR]"
+                            payload["isDeleted"] = True
                             self.filesystem.write_item("posts", post_id, payload)
                     result = self.filesystem.delete_item("usersv0", client)
                     if result:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ bcrypt
 scratch2py
 uuid
 flask
+pymongo


### PR DESCRIPTION
## Changes:
-Filesystem now connects to MongoDB instead of using JSON files
-Create post is now seperated from the individual function, added types (type 1: home/chat post, type 2: announcement, type 3: inbox message)
-Added epoch time to timestamp object (mode 1)
-When user logs in their IP will be logged to the 'netlog' collection which keeps track of which users have logged in on which IPs
-Added `last_ip` to userdata items, this will now be used inside of IP ban commands instead of the websocket object IP
-`get_home` and `/home` REST API return the last 25 non-deleted posts, not just the last 25 posts over the last 24 hours
-Clear home now clears the last page, but can also take the arguement of page to delete a certain page
-Group chats now have a lot more permission checking, the only command that still doesn't do permission checking is `set_chat_state`
-When sending a post in a group chat it'll only send to members that are part of the group chat
-System status (`repair_mode` and `is_deprecated`) will now be returned from an item in the DB, also the CL server will respect those values and will disallow new connections if repair mode is enabled
-`get_post` and `get_chat_post` have been combined into just `get_post`
-Indexes just use mode 3 (IIRC) and no longer have the option to convert, just to make things more refined and Scratch can grow up and handle normal arrays anyway
-`delete_post` can now be ran by the OP (original poster) or a level 1+ moderator
-`get_chat_list` will return an index of all group chats the user is part of
-`get_chat_data` will return data like nickname, owner and members of a group chat
-Doing `leave_chat` while the owner of the chat will result in the chat being deleted
-Moderators (level 1+) can download any post no matter what permissions it requires
-Moderators can get back the full post payload through get_post when a post is deleted


## Added Commands/Features:
**GDPR:** `del_account` (level 0 and below, so moderators don't accidently delete their moderator account while developing stuff) - Delete every post they've made (including post sender, post content, and isDeleted=True), remove them from every group chat, remove them from every netlog, and delete their userdata item and log them out
`get_inbox` (level 0 and above) - Returns an index of a user's inbox messages
`get_announcements` (level 0 and above) - Returns and index of Meower Team announcements
`clear_user_posts` (level 2 and above) - Clear all of a user's posts
`alert` (level 1 and above) - Sends a moderator alert to a user
`announce` (level 3 and above) - Creates a new announcement
`get_ip_data` (level 2 and above) - Returns netlog data about an IP address
`terminate` (level 4 and above) - Deletes and bans a user account
`repair_mode` (level 4 and above) - Enables repair mode on the server
`get_chat_posts` (level 0 and above) - Returns an index of posts in a group chat
`remove_from_chat` (level 0 and above) - Removes someone from a group chat


## Things That Broke
Here are the things that have broken in the Beta 5 R4 client:
-Cannot see names of group chats
-Cannot connect, disconnect or send messages in group chats (live chat still works)
-Cannot see a user's recent posts


## Side Note
There was too many things to list here, if I were to go into detail about everything I would be here for hours and it's already 12:30am when I'm writing this. I've spent the last 2 days working on this. 

Another thing, I want `set_chat_state` deprecated in Beta 6, it's not really needed and is kinda pain to get it to work with new post format.