### PR TITLE
Fix username duplicates

### DIFF
--- a/files.py
+++ b/files.py
@@ -32,6 +32,7 @@ class Files:
         
         # Create collection indexes
         self.db["netlog"].create_index("users")
+        self.db["usersv0"].create_index("lower_username")
         self.db["posts"].create_index("u")
         self.db["posts"].create_index("post_origin")
         self.db["posts"].create_index("type")
@@ -39,6 +40,7 @@ class Files:
         
         # Create reserved accounts
         self.create_item("usersv0", "Server", {
+            "lower_username": "server",
             "theme": "",
             "mode": None,
             "sfx": None,
@@ -55,6 +57,7 @@ class Files:
         })
         
         self.create_item("usersv0", "Deleted", {
+            "lower_username": "deleted",
             "theme": "",
             "mode": None,
             "sfx": None,
@@ -71,6 +74,7 @@ class Files:
         })
 
         self.create_item("usersv0", "username", {
+            "lower_username": "username",
             "theme": "",
             "mode": None,
             "sfx": None,
@@ -87,6 +91,7 @@ class Files:
         })
 
         self.create_item("usersv0", "Meower", {
+            "lower_username": "meower",
             "theme": "",
             "mode": None,
             "sfx": None,
@@ -139,6 +144,15 @@ class Files:
             "is_deprecated": False
         })
         
+        # 'lower_username' patch
+        result, payload = self.load_item("usersv0", "Server")
+        if result:
+            if not "lower_username" in payload:
+                self.log("Updating users to include 'lower_username'")
+                payload = self.find_items("usersv0", {})
+                for item in payload:
+                    self.update_item("usersv0", str(item), {"lower_username": str(item).lower()})
+
         self.log("Files initialized!")
 
     def does_item_exist(self, collection, id):
@@ -161,6 +175,16 @@ class Files:
                 return False
         else:
             self.log("{0} collection doesn't exist".format(collection))
+            return False
+
+    def update_item(self, collection, id, data):
+        if collection in self.db.list_collection_names():
+            if self.does_item_exist(collection, id):
+                self.db[collection].update_one({"_id": id}, {"$set": data})
+                return True
+            else:
+                return False
+        else:
             return False
 
     def write_item(self, collection, id, data):

--- a/meower.py
+++ b/meower.py
@@ -1069,7 +1069,8 @@ class Meower:
                             for post_id in all_posts:
                                 result, payload = self.filesystem.load_item("posts", post_id)
                                 if result:
-                                    payload["isDeleted"] = True
+                                    payload["u"] = "Deleted"
+                                    payload["p"] = "[This user was deleted]"
                                     self.filesystem.write_item("posts", post_id, payload)
                             FileCheck, FileRead, FileWrite = self.accounts.update_setting(val, {"theme": None, "mode": None, "sfx": None, "debug": None, "bgm": None, "bgm_song": None, "layout": None, "pfp_data": None, "quote": None, "email": None, "pswd": None, "lvl": None, "banned": True, "last_ip": None}, forceUpdate=True)
                             if FileCheck and FileRead and FileWrite:
@@ -1695,26 +1696,8 @@ class Meower:
                         result, payload = self.filesystem.load_item("posts", post_id)
                         if result:
                             payload["u"] = "Deleted"
-                            payload["p"] = "[This user was deleted - GDPR]"
-                            payload["isDeleted"] = True
+                            payload["p"] = "[This user was deleted]"
                             self.filesystem.write_item("posts", post_id, payload)
-                    chat_index = self.getIndex(location="chats", query={"members": {"$all": [client]}}, truncate=False)["index"]
-                    for chat_id in chat_index:
-                        result, payload = self.filesystem.load_item("chats", chat_id)
-                        if result:
-                            if payload["owner"] == client:
-                                self.filesystem.delete_item("chats", chat_id)
-                            else:
-                                payload["members"].remove(client)
-                                self.filesystem.write_item("chats", chat_id, payload)
-                    netlog_index = self.getIndex(location="netlog", query={"users": {"$all": [client]}}, truncate=False)["index"]
-                    for ip in netlog_index:
-                        result, payload = self.filesystem.load_item("netlog", ip)
-                        if result:
-                            payload["users"].remove(client)
-                            if payload["last_user"] == client:
-                                payload["last_user"] = "Deleted"
-                            self.filesystem.write_item("netlog", ip, payload)
                     result = self.filesystem.delete_item("usersv0", client)
                     if result:
                         self.returnCode(client = client, code = "OK", listener_detected = listener_detected, listener_id = listener_id)

--- a/security.py
+++ b/security.py
@@ -30,11 +30,12 @@ class Security:
         """
         
         if (type(password) == str) and (type(username) == str):
-            if not self.files.does_item_exist("usersv0", str(username)):
+            if not self.account_exists(str(username), ignore_case=True):
                 self.log("Creating account: {0}".format(username))
                 pswd_bytes = bytes(password, "utf-8") # Convert password to bytes
                 hashed_pw = self.bc.hashpw(pswd_bytes, self.bc.gensalt(strength)) # Hash and salt the password
                 result = self.files.create_item("usersv0", str(username), { # Default account data
+                        "lower_username": username.lower(),
                         "theme": "orange",
                         "mode": True,
                         "sfx": True,
@@ -191,9 +192,16 @@ class Security:
             self.log("Error on get_account: Expected str for username, oldpassword and newpassword, got {0} for username, {1} for oldpassword, and {2} for newpassword".format(type(username), type(oldpassword), type(newpassword)))
             return False, False, False
     
-    def account_exists(self, username):
+    def account_exists(self, username, ignore_case=False):
         if type(username) == str:
-            return self.files.does_item_exist("usersv0", str(username))
+            if ignore_case:
+                payload = self.files.find_items("usersv0", {"lower_username": str(username).lower()})
+                if len(payload) == 0:
+                    return False
+                else:
+                    return True
+            else:
+                return self.files.does_item_exist("usersv0", str(username))
         else:
             self.log("Error on account_exists: Expected str for username, got {0}".format(type(username)))
             return False


### PR DESCRIPTION
Fixes username duplicates by adding a 'lower_username' to a user's userdata, this is checked when creating new accounts to make sure duplicate accounts with different capitalization won't be created.