### PR TITLE
Add creation timestamps for new accounts

### DIFF
--- a/security.py
+++ b/security.py
@@ -1,4 +1,5 @@
 import bcrypt
+import time
 from uuid import uuid4
 
 """
@@ -35,6 +36,7 @@ class Security:
                 hashed_pw = self.bc.hashpw(pswd_bytes, self.bc.gensalt(strength)) # Hash and salt the password
                 result = self.files.create_item("usersv0", str(username), { # Default account data
                         "lower_username": username.lower(),
+                        "created": int(time.time()),
                         "uuid": str(uuid4()),
                         "unread_inbox": False,
                         "theme": "orange",


### PR DESCRIPTION
Run this before restarting the server:

```python
from pymongo import MongoClient
import time

db = MongoClient("mongodb://localhost:27017")

for message in list(db.posts.find({"p": {"$regex": "Welcome to Meower"}})):
    try:
        db.usersv0.update_one({"_id": message["u"]}, {"$set": {"created": message["t"]["e"]}})
    except:
        pass

db.usersv0.update_many({"$or": [{"created": None}, {"created": 1636929928}]}, {"created": int(time.time())})```