### PR TITLE
`__pycashe__/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-__pycashe__/
+__pycache__/


### PR DESCRIPTION
Fixes a typo in the `.gitignore` file.