### PR TITLE
ignore unknown frames

### DIFF
--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -325,7 +325,7 @@ class WebSocketHandler(StreamRequestHandler):
             opcode_handler = self.server._pong_received_
         else:
             logger.warning("Unknown opcode %#x." % opcode)
-	    return        
+            return        
 
         if payload_length == 126:
             payload_length = struct.unpack(">H", self.rfile.read(2))[0]

--- a/websocket_server/websocket_server.py
+++ b/websocket_server/websocket_server.py
@@ -325,8 +325,7 @@ class WebSocketHandler(StreamRequestHandler):
             opcode_handler = self.server._pong_received_
         else:
             logger.warning("Unknown opcode %#x." % opcode)
-            self.keep_alive = 0
-            return
+	    return        
 
         if payload_length == 126:
             payload_length = struct.unpack(">H", self.rfile.read(2))[0]


### PR DESCRIPTION
Makes the ws server ignore unknown frames because it is closing the connection when a singular reserved frame is being sent.